### PR TITLE
[BUG] ConversationService is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,8 +127,8 @@ class S2sStarterkit {
         return this._sdkEngine.BubbleService;
     }
 
-    get Conversationservice() {
-        return this._sdkEngine.Conversationservice;
+    get ConversationService() {
+        return this._sdkEngine.ConversationService;
     }
 }
 module.exports = S2sStarterkit;


### PR DESCRIPTION
**Context:** Found this bug when trying to look up all conversations in an account. 
**Expected behavior:** calling `myS2sStarterkit.ConversationService.getAllConversations();` returns a list of conversations. 
**What happened:** Got the following error – "Undefined object" 

I tracked it down to a misspelling. Fixed the issue. Tested it locally and it seems to be working. 
